### PR TITLE
Backport Browser#chromium_based? when browser gem version is 5.x or below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 - [View Diff](https://github.com/westonganger/rails_local_analytics/compare/v0.1.0...master)
-- Nothing yet
+- Backport `Browser#chromium_based?` when `browser` gem version is 5.x or below.
 
 ### v0.1.0 - Dec 3 2024
 - Initial gem release

--- a/config/initializers/browser_monkey_patches.rb
+++ b/config/initializers/browser_monkey_patches.rb
@@ -1,0 +1,19 @@
+if Browser::VERSION.to_f < 6.0
+  Browser::Base.class_eval do
+    def chromium_based?
+      false
+    end
+  end
+
+  Browser::Chrome.class_eval do
+    def chromium_based?
+      true
+    end
+  end
+
+  Browser::Edge.class_eval do
+    def chromium_based?
+      match? && ua.match?(/\bEdg\b/)
+    end
+  end
+end


### PR DESCRIPTION
Backport `Browser#chromium_based?` when `browser` gem version is 5.x or below.

Seems that the browser gem v6.0.0 went a little too aggressive on the Ruby version dependency (min Ruby 3.2), so we'd rather backport the fixes for the old gem.