### PR TITLE
Fix KeyError when using `config.background_jobs = false` due to not stringifying the keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 - [View Diff](https://github.com/westonganger/rails_local_analytics/compare/v0.2.3...master)
-- Nothing yet
+- [#18](https://github.com/westonganger/rails_local_analytics/pull/18) - Fix KeyError when using `config.background_jobs = false` due to not stringifying the keys
 
 ### v0.2.3 - Dec 17 2024
 - [View Diff](https://github.com/westonganger/rails_local_analytics/compare/v0.2.2...v0.2.3)

--- a/lib/rails_local_analytics.rb
+++ b/lib/rails_local_analytics.rb
@@ -29,7 +29,7 @@ module RailsLocalAnalytics
       json_str = JSON.generate(json_hash) # convert to json string so that its compatible with all job backends
       RecordRequestJob.perform_later(json_str)
     else
-      RecordRequestJob.new.perform(json_hash)
+      RecordRequestJob.new.perform(json_hash.deep_stringify_keys)
     end
   end
 
@@ -44,11 +44,18 @@ module RailsLocalAnalytics
   end
 
   class Config
-    @@background_jobs = true
+    DEFAULTS = {
+      background_jobs: true,
+    }.freeze
+
     mattr_reader :background_jobs
 
     def self.background_jobs=(val)
       @@background_jobs = !!val
+    end
+
+    DEFAULTS.each do |k,v|
+      self.send("#{k}=", v)
     end
   end
 

--- a/spec/model/rails_local_analytics_spec.rb
+++ b/spec/model/rails_local_analytics_spec.rb
@@ -8,14 +8,6 @@ RSpec.describe RailsLocalAnalytics, type: :model do
   end
 
   context "config.background_jobs" do
-    before do
-      @prev_background_jobs = described_class.config.background_jobs
-    end
-
-    after do
-      described_class.config.background_jobs = @prev_background_jobs
-    end
-
     it "defaults to true" do
       expect(described_class.config.background_jobs).to eq(true)
     end

--- a/spec/request/record_request_spec.rb
+++ b/spec/request/record_request_spec.rb
@@ -26,4 +26,28 @@ RSpec.describe "RailsLocalAnalytics#record_request", type: :request do
       "url_path" => "/",
     })
   end
+
+  it "works with config.background_jobs = false" do
+    RailsLocalAnalytics.config.background_jobs = false
+
+    get root_path
+    expect(response.status).to eq(200)
+
+    expect(TrackedRequestsByDaySite.last.attributes.except("id")).to eq({
+      "browser_engine" => nil,
+      "day" => Date.today,
+      "platform" => nil,
+      "total" => 1,
+      "url_hostname" => "www.example.com",
+    })
+
+    expect(TrackedRequestsByDayPage.last.attributes.except("id")).to eq({
+      "day" => Date.today,
+      "referrer_hostname" => nil,
+      "referrer_path" => nil,
+      "total" => 1,
+      "url_hostname" => "www.example.com",
+      "url_path" => "/",
+    })
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,10 @@ RSpec.configure do |config|
     DatabaseCleaner.cleaning do
       example.run
     end
+
+    RailsLocalAnalytics::Config::DEFAULTS.each do |k,v|
+      RailsLocalAnalytics.config.send("#{k}=", v)
+    end
   end
 
   require 'rails-controller-testing'


### PR DESCRIPTION
Solves part of #18 